### PR TITLE
configure the mac addr via env vars

### DIFF
--- a/examples/macvtap-nad.yml
+++ b/examples/macvtap-nad.yml
@@ -8,6 +8,5 @@ spec:
       "type": "macvtap",
       "master": "eth0",
       "mode": "bridge",
-      "mac": "52:54:00:11:11:11",
       "mtu": 1500
     }'

--- a/examples/pod-specify-mac.yml
+++ b/examples/pod-specify-mac.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: samplepod-with-mac-1
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+        {
+          "name": "macvtap0",
+          "mac": "52:54:00:11:11:11"
+        }
+    ]'
+spec:
+  containers:
+  - name: samplepod
+    command: ["sleep", "99999"]
+    image: fedora


### PR DESCRIPTION
Up to now, the mac address was being defined on the
network-attachment-definition. This is extremelly inneficient,
since it requires 1 NAD per each pod.

By setting the MAC address via a runtime parameter, indicated in
the pod / vmi network annotation it is possible to have a single
NAD per logical network.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>