### PR TITLE
Specify the link qlen parameter

### DIFF
--- a/macvtap.go
+++ b/macvtap.go
@@ -151,6 +151,7 @@ func createMacvtap(conf *NetConf, ifName string, netns ns.NetNS) (*current.Inter
 				Name:        tmpName,
 				ParentIndex: m.Attrs().Index,
 				Namespace:   netlink.NsFd(int(netns.Fd())),
+				TxQLen:      m.Attrs().TxQLen,
 			},
 			Mode: mode,
 		},


### PR DESCRIPTION
Macvtap interfaces created via netlink are appearing without a
defined qlen, which leads to the whole k8s node where the pod
is scheduled to explode.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>